### PR TITLE
Require password to access application

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>高校生向け求人・進学先検索アプリ</title>
     <link rel="stylesheet" href="styles.css">
 </head>
-<body>
+<body class="auth-locked">
     <header>
         <h1>求人・進学先検索</h1>
         <nav>

--- a/script.js
+++ b/script.js
@@ -10,6 +10,9 @@ let sortOrder = 'asc';
 let favorites = JSON.parse(localStorage.getItem('favorites') || '[]');
 let currentFilters = {};
 
+const AUTH_PASSWORD = 'visionwell1001';
+let isAuthenticated = false;
+
 // DOM要素
 const elements = {
     uploadSection: document.getElementById('uploadSection'),
@@ -33,10 +36,31 @@ const elements = {
 
 // 初期化
 document.addEventListener('DOMContentLoaded', function() {
+    enforceAuthentication();
+});
+
+function initializeApp() {
     setupEventListeners();
     loadTheme();
     checkForSampleData();
-});
+}
+
+function enforceAuthentication() {
+    while (!isAuthenticated) {
+        const input = prompt('このアプリを利用するにはパスワードが必要です。パスワードを入力してください。');
+
+        if (input === null) {
+            alert('パスワードが入力されるまでアプリを利用できません。');
+        } else if (input === AUTH_PASSWORD) {
+            isAuthenticated = true;
+            document.body.classList.remove('auth-locked');
+            initializeApp();
+            break;
+        } else {
+            alert('パスワードが違います。');
+        }
+    }
+}
 
 // イベントリスナー設定
 function setupEventListeners() {

--- a/styles.css
+++ b/styles.css
@@ -51,6 +51,10 @@ body {
     transition: background-color 0.3s ease, color 0.3s ease;
 }
 
+body.auth-locked {
+    display: none;
+}
+
 .container {
     max-width: 1200px;
     margin: 0 auto;


### PR DESCRIPTION
## Summary
- hide the UI by default until a valid password is provided
- add a client-side password prompt before initializing the application logic

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ccd24b241c832e861b52d2a3574a69