### PR TITLE
Handle Shift_JIS encoding for sample CSV

### DIFF
--- a/script.js
+++ b/script.js
@@ -1395,7 +1395,23 @@ async function fetchDatasetFile(type) {
         throw new Error('サンプルデータの読み込みに失敗しました。');
     }
 
-    const text = await response.text();
+    const buffer = await response.arrayBuffer();
+    let text;
+
+    try {
+        // UTF-8でデコード（失敗した場合は例外を投げる）
+        const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
+        text = utf8Decoder.decode(buffer);
+    } catch (utf8Error) {
+        try {
+            // Shift_JISで再デコード
+            const sjisDecoder = new TextDecoder('shift_jis');
+            text = sjisDecoder.decode(buffer);
+        } catch (sjisError) {
+            throw new Error('サンプルデータの文字コードを認識できませんでした。');
+        }
+    }
+
     return parseCSV(text);
 }
 


### PR DESCRIPTION
## Summary
- decode fetched sample CSVs using TextDecoder and retry with Shift_JIS when UTF-8 decoding fails
- ensure sample datasets encoded in Shift_JIS display correctly instead of showing unknown values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccd8ed76e8832ea24ffdb515a5d629