### PR TITLE
Stack search filters above result cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
                 </aside>
 
                 <!-- メインコンテンツ -->
-                <main class="main-content">
+                <section class="main-content">
                     <!-- 検索・ソートバー -->
                     <div class="search-sort-bar">
                         <div class="search-box">
@@ -65,7 +65,7 @@
                     <div class="pagination" id="pagination">
                         <!-- ページネーションはJavaScriptで動的に生成 -->
                     </div>
-                </main>
+                </section>
             </div>
         </section>
     </main>

--- a/styles.css
+++ b/styles.css
@@ -149,9 +149,9 @@ header h1 {
 }
 
 .data-section .container {
-    display: grid;
-    grid-template-columns: 280px 1fr;
-    gap: 30px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
 }
 
 /* フィルタパネル */
@@ -160,11 +160,13 @@ header h1 {
     padding: 20px;
     border-radius: 12px;
     box-shadow: var(--shadow);
-    height: fit-content;
-    position: sticky;
-    top: 100px;
-    max-height: calc(100vh - 120px);
-    overflow-y: auto;
+    width: 100%;
+}
+
+.main-content {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
 }
 
 .filter-panel h3 {
@@ -984,12 +986,7 @@ header h1 {
 /* レスポンシブ対応 */
 @media (max-width: 1024px) {
     .data-section .container {
-        grid-template-columns: 260px 1fr;
         gap: 20px;
-    }
-    
-    .filter-panel {
-        max-height: calc(100vh - 140px);
     }
 }
 
@@ -1002,15 +999,7 @@ header h1 {
         font-size: 1.2rem;
     }
     
-    .data-section .container {
-        grid-template-columns: 1fr;
-        gap: 20px;
-    }
-    
     .filter-panel {
-        position: static;
-        margin-bottom: 20px;
-        max-height: none;
         padding: 15px;
     }
     


### PR DESCRIPTION
## Summary
- update the main layout to present the filter panel above the results
- adjust associated styles for the vertical arrangement of filters and cards

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d0ab883bb0832eaa95b77dc1b135d4