### PR TITLE
Move dataset tabs to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,10 +8,24 @@
 </head>
 <body class="auth-locked">
     <header>
-        <h1>求人・進学先検索</h1>
-        <nav>
-            <button id="themeToggle" class="btn btn-secondary">🌙 ダークモード</button>
-        </nav>
+        <div class="container header-bar">
+            <div class="header-main">
+                <h1>求人・進学先検索</h1>
+                <nav class="dataset-nav">
+                    <button class="nav-item active" data-dataset="job">
+                        <span class="nav-icon">💼</span>
+                        <span class="nav-label">就職</span>
+                    </button>
+                    <button class="nav-item" data-dataset="school">
+                        <span class="nav-icon">🎓</span>
+                        <span class="nav-label">進学</span>
+                    </button>
+                </nav>
+            </div>
+            <div class="header-actions">
+                <button id="themeToggle" class="btn btn-secondary">🌙 ダークモード</button>
+            </div>
+        </div>
     </header>
 
     <main>
@@ -79,18 +93,6 @@
             </div>
         </div>
     </div>
-
-    <!-- ナビゲーションメニュー -->
-    <nav class="bottom-nav">
-        <button class="nav-item active" data-dataset="job">
-            <span class="nav-icon">💼</span>
-            <span class="nav-label">就職</span>
-        </button>
-        <button class="nav-item" data-dataset="school">
-            <span class="nav-icon">🎓</span>
-            <span class="nav-label">進学</span>
-        </button>
-    </nav>
 
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -396,7 +396,7 @@ function setupEventListeners() {
 }
 
 function setupDatasetTabs() {
-    const tabs = document.querySelectorAll('.bottom-nav .nav-item');
+    const tabs = document.querySelectorAll('.dataset-nav .nav-item');
 
     tabs.forEach(tab => {
         tab.addEventListener('click', () => {
@@ -1959,7 +1959,7 @@ function applyDataset(type) {
 }
 
 function setActiveDatasetTab(type) {
-    const tabs = document.querySelectorAll('.bottom-nav .nav-item');
+    const tabs = document.querySelectorAll('.dataset-nav .nav-item');
 
     tabs.forEach(tab => {
         if (tab.dataset.dataset === type) {

--- a/styles.css
+++ b/styles.css
@@ -84,6 +84,36 @@ header h1 {
     font-weight: bold;
 }
 
+.header-bar {
+    gap: 24px;
+    flex-wrap: wrap;
+}
+
+.header-main {
+    display: flex;
+    align-items: center;
+    gap: 24px;
+    flex-wrap: wrap;
+}
+
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.dataset-nav {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 4px;
+    background-color: var(--surface-color);
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    box-shadow: var(--shadow);
+    flex-wrap: wrap;
+}
+
 /* ボタンスタイル */
 .btn {
     padding: 8px 16px;
@@ -937,48 +967,43 @@ header h1 {
     font-size: 12px;
 }
 
-/* ボトムナビゲーション */
-.bottom-nav {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: var(--surface-color);
-    border-top: 1px solid var(--border-color);
-    display: flex;
-    justify-content: center;
-    padding: 8px 0;
-    z-index: 100;
-}
-
-.nav-item {
-    display: flex;
-    flex-direction: column;
+/* データセットタブ */
+.dataset-nav .nav-item {
+    display: inline-flex;
     align-items: center;
-    padding: 8px 24px;
+    gap: 6px;
+    padding: 8px 16px;
     background: none;
     border: none;
+    border-radius: 999px;
     color: var(--text-secondary);
     cursor: pointer;
-    transition: color 0.3s ease;
+    transition: background-color 0.3s ease, color 0.3s ease;
     text-decoration: none;
 }
 
-.nav-item:hover {
+.dataset-nav .nav-item:hover {
+    background-color: rgba(52, 152, 219, 0.1);
     color: var(--primary-color);
 }
 
-.nav-item.active {
-    color: var(--primary-color);
+.dataset-nav .nav-item.active {
+    background-color: var(--primary-color);
+    color: #ffffff;
+}
+
+.dataset-nav .nav-item.active .nav-icon {
+    color: #ffffff;
 }
 
 .nav-icon {
-    font-size: 20px;
-    margin-bottom: 4px;
+    font-size: 18px;
+    margin: 0;
 }
 
 .nav-label {
-    font-size: 12px;
+    font-size: 14px;
+    font-weight: 500;
 }
 
 /* レスポンシブ対応 */
@@ -997,11 +1022,32 @@ header h1 {
     .container {
         padding: 0 15px;
     }
-    
+
     header h1 {
         font-size: 1.2rem;
     }
-    
+
+    .header-bar {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 16px;
+    }
+
+    .header-actions {
+        width: 100%;
+        justify-content: flex-start;
+    }
+
+    .dataset-nav {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .dataset-nav .nav-item {
+        flex: 1 1 auto;
+        justify-content: center;
+    }
+
     .data-section .container {
         grid-template-columns: 1fr;
         gap: 20px;
@@ -1265,7 +1311,7 @@ header h1 {
 /* プリント対応 */
 @media print {
     .modal,
-    .bottom-nav,
+    .dataset-nav,
     .filter-panel,
     .search-sort-bar,
     .pagination {


### PR DESCRIPTION
## Summary
- move the 就職・進学タブ into the header beside the title for easier access
- restyle the dataset toggle buttons for their new header placement, including responsive tweaks
- update JavaScript selectors to work with the new dataset tab container

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d0abcd8598832ea75ff97fc8bf64c6