### PR TITLE
Remove job classification code filter from job search

### DIFF
--- a/script.js
+++ b/script.js
@@ -1070,13 +1070,6 @@ function getFilterConfig(dataType) {
                 description: '働きたい都道府県を選択'
             },
             {
-                field: '職業分類コード',
-                label: '🧭 職種分類コード',
-                type: 'select',
-                priority: 1,
-                description: '気になる職種分類コードを選択'
-            },
-            {
                 field: '職種大分類',
                 label: '🧭 職種大分類',
                 type: 'job_classification',


### PR DESCRIPTION
## Summary
- remove the job classification code select filter from the job dataset configuration so it no longer appears in the search panel

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d13fcb2840832eb2439a6704ca0790